### PR TITLE
updated readme.md regarding issue with usb storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ installed to USB.
 ## Installation
 
 1. Make sure your USB storage drive is formatted to a single FAT, FAT32, or 
-exFAT partition using the MBR partition scheme.
+exFAT partition using the MBR partition scheme. (For devices over 32GB, it is recommended to format to 64kb or 32kb cluster sizes)
 2. Install the vpk
 3. Run usbmc to start the installer
 4. Press X to install the plugin.


### PR DESCRIPTION
Others have had similar issues regarding memory sizes over 32GB as have I. I found that the solution is to use a smaller cluster size than default.

The default cluster size changes at the 32GB mark according to Microsoft: https://support.microsoft.com/en-us/help/140365/default-cluster-size-for-ntfs-fat-and-exfat

The thread discussing the problem in more detail can be found here: https://www.reddit.com/r/vitahacks/comments/7zlxxm/schr%C3%B6dingers_usb_both_filled_empty/

